### PR TITLE
install iproute2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM alpine:3.18
 
 RUN apk add --no-cache bird=2.13-r0 \
-    tcpdump iproute2
+    tcpdump \
+    iproute2
 
 
 ENTRYPOINT ["/usr/sbin/bird", "-c", "/etc/bird.conf", "-d"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.18
 
 RUN apk add --no-cache bird=2.13-r0 \
-    tcpdump
+    tcpdump iproute2
 
 
 ENTRYPOINT ["/usr/sbin/bird", "-c", "/etc/bird.conf", "-d"]


### PR DESCRIPTION
Busybox's "ip" command is no bueno for serious labbing as it can't display multipath and MPLS routes, among other restrictions. Install iproute2 to solve that problem.